### PR TITLE
Segregated lineType to track and progress Types

### DIFF
--- a/app/src/main/java/com/binayshaw7777/kotstep/MainActivity.kt
+++ b/app/src/main/java/com/binayshaw7777/kotstep/MainActivity.kt
@@ -145,9 +145,12 @@ fun MainPreview() {
                 linePaddingTop = lineTopPadding.dp,
                 linePaddingBottom = lineBottomPadding.dp,
                 strokeCap = strokeCap,
-                todoLineType = LineType.DOTTED,
-                currentLineType = LineType.DASHED,
-                doneLineType = LineType.SOLID
+                todoLineTrackType = LineType.DOTTED,
+                currentLineTrackType = LineType.DASHED,
+                doneLineTrackType = LineType.SOLID,
+                todoLineProgressType = LineType.DOTTED,
+                currentLineProgressType = LineType.SOLID,
+                doneLineProgressType = LineType.SOLID
             ),
             showCheckMarkOnDone = showCheckMark,
             showStrokeOnCurrent = showStepStroke,

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/divider/KotStepHorizontalDivider.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/divider/KotStepHorizontalDivider.kt
@@ -23,9 +23,10 @@ internal fun KotStepHorizontalDivider(
     height: Dp = 1.dp,
     lineTrackColor: Color = Color.Gray,
     lineProgressColor: Color = Color.Black,
-    lineStyle: LineType = LineType.SOLID,
+    lineTrackStyle: LineType = LineType.SOLID,
+    lineProgressStyle: LineType = LineType.SOLID,
     progress: Float = 1f,
-    strokeCap: StrokeCap = StrokeCap.Round  // New parameter
+    strokeCap: StrokeCap = StrokeCap.Round
 ) {
     val animatedProgress by animateFloatAsState(
         targetValue = progress.coerceIn(0f, 1f),
@@ -39,30 +40,51 @@ internal fun KotStepHorizontalDivider(
             .width(width)
             .height(height)
     ) {
-        val pathEffect = when (lineStyle) {
+        val trackPathEffect = when (lineTrackStyle) {
+            LineType.SOLID -> null
+            LineType.DASHED -> PathEffect.dashPathEffect(floatArrayOf(10f, 10f), 0f)
+            LineType.DOTTED -> PathEffect.dashPathEffect(floatArrayOf(5f, 5f), 0f)
+        }
+        val progressPathEffect = when (lineProgressStyle) {
             LineType.SOLID -> null
             LineType.DASHED -> PathEffect.dashPathEffect(floatArrayOf(10f, 10f), 0f)
             LineType.DOTTED -> PathEffect.dashPathEffect(floatArrayOf(5f, 5f), 0f)
         }
 
-        if (lineStyle != LineType.DOTTED) {
-            // Draw background line
+        // Draw background line
+        if (lineTrackStyle != LineType.DOTTED) {
             drawLine(
                 color = lineTrackColor,
                 start = Offset(0f, size.height / 2),
                 end = Offset(size.width, size.height / 2),
                 strokeWidth = height.toPx(),
-                pathEffect = pathEffect,
+                pathEffect = trackPathEffect,
                 cap = strokeCap
             )
+        } else {
+            val dotRadius = height.toPx() / 2
+            val spaceBetweenDots = dotRadius * 4
+            val totalDots = (size.width / spaceBetweenDots).toInt()
 
-            // Draw progress line
+            for (i in 0 until totalDots) {
+                val x = i * spaceBetweenDots + dotRadius
+
+                drawCircle(
+                    color = if (x <= size.width * animatedProgress) lineProgressColor else lineTrackColor,
+                    radius = dotRadius,
+                    center = Offset(x, size.height / 2)
+                )
+            }
+        }
+
+        // Draw progress line
+        if (lineProgressStyle != LineType.DOTTED) {
             drawLine(
                 color = lineProgressColor,
                 start = Offset(0f, size.height / 2),
                 end = Offset(size.width * animatedProgress, size.height / 2),
                 strokeWidth = height.toPx(),
-                pathEffect = pathEffect,
+                pathEffect = progressPathEffect,
                 cap = strokeCap
             )
         } else {

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/divider/KotStepVerticalDivider.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/divider/KotStepVerticalDivider.kt
@@ -23,7 +23,8 @@ internal fun KotStepVerticalDivider(
     width: Dp = 1.dp,
     lineTrackColor: Color = Color.Gray,
     lineProgressColor: Color = Color.Black,
-    lineStyle: LineType = LineType.SOLID,
+    lineTrackStyle: LineType = LineType.SOLID,
+    lineProgressStyle: LineType = LineType.SOLID,
     progress: Float = 1f,
     strokeCap: StrokeCap = StrokeCap.Round
 ) {
@@ -39,30 +40,54 @@ internal fun KotStepVerticalDivider(
             .width(width)
             .height(height)
     ) {
-        val pathEffect = when (lineStyle) {
+
+        val trackPathEffect = when (lineTrackStyle) {
             LineType.SOLID -> null
             LineType.DASHED -> PathEffect.dashPathEffect(floatArrayOf(10f, 10f), 0f)
             LineType.DOTTED -> PathEffect.dashPathEffect(floatArrayOf(5f, 5f), 0f)
         }
 
-        if (lineStyle != LineType.DOTTED) {
-            // Draw background line
+        val progressPathEffect = when (lineProgressStyle) {
+            LineType.SOLID -> null
+            LineType.DASHED -> PathEffect.dashPathEffect(floatArrayOf(10f, 10f), 0f)
+            LineType.DOTTED -> PathEffect.dashPathEffect(floatArrayOf(5f, 5f), 0f)
+        }
+
+        // Draw background line
+        if (lineTrackStyle != LineType.DOTTED) {
             drawLine(
                 color = lineTrackColor,
                 start = Offset(size.width / 2, 0f),
                 end = Offset(size.width / 2, size.height),
                 strokeWidth = width.toPx(),
-                pathEffect = pathEffect,
+                pathEffect = trackPathEffect,
                 cap = strokeCap
             )
 
-            // Draw progress line
+        } else {
+            val dotRadius = width.toPx() / 2
+            val spaceBetweenDots = dotRadius * 4
+            val totalDots = (size.height / spaceBetweenDots).toInt()
+
+            for (i in 0 until totalDots) {
+                val y = i * spaceBetweenDots + dotRadius
+
+                drawCircle(
+                    color = lineProgressColor,
+                    radius = dotRadius,
+                    center = Offset(size.width / 2, y)
+                )
+            }
+        }
+
+        // Draw progress line
+        if (lineProgressStyle != LineType.DOTTED) {
             drawLine(
                 color = lineProgressColor,
                 start = Offset(size.width / 2, 0f),
                 end = Offset(size.width / 2, size.height * animatedProgress),
                 strokeWidth = width.toPx(),
-                pathEffect = pathEffect,
+                pathEffect = progressPathEffect,
                 cap = strokeCap
             )
         } else {

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/horizontal/HorizontalIconStep.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/horizontal/HorizontalIconStep.kt
@@ -83,10 +83,16 @@ internal fun HorizontalIconStep(
         }
     }
 
-    val lineStyle: LineType = when (stepState) {
-        StepState.TODO -> stepStyle.lineStyle.todoLineType
-        StepState.CURRENT -> stepStyle.lineStyle.currentLineType
-        StepState.DONE -> stepStyle.lineStyle.doneLineType
+    val lineTrackStyle: LineType = when (stepState) {
+        StepState.TODO -> stepStyle.lineStyle.todoLineTrackType
+        StepState.CURRENT -> stepStyle.lineStyle.currentLineTrackType
+        StepState.DONE -> stepStyle.lineStyle.doneLineTrackType
+    }
+
+    val lineProgressStyle: LineType = when (stepState) {
+        StepState.TODO -> stepStyle.lineStyle.todoLineProgressType
+        StepState.CURRENT -> stepStyle.lineStyle.currentLineProgressType
+        StepState.DONE -> stepStyle.lineStyle.doneLineProgressType
     }
 
     val strokeCap: StrokeCap = when (stepState) {
@@ -156,7 +162,8 @@ internal fun HorizontalIconStep(
                 width = stepStyle.lineStyle.lineSize,
                 lineTrackColor = stepStyle.colors.todoLineColor,
                 lineProgressColor = lineColor,
-                lineStyle = lineStyle,
+                lineTrackStyle = lineTrackStyle,
+                lineProgressStyle = lineProgressStyle,
                 progress = lineProgress,
                 strokeCap = strokeCap
             )

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/horizontal/HorizontalNumberedStep.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/horizontal/HorizontalNumberedStep.kt
@@ -85,10 +85,16 @@ internal fun HorizontalNumberedStep(
         }
     }
 
-    val lineStyle: LineType = when (stepState) {
-        StepState.TODO -> stepStyle.lineStyle.todoLineType
-        StepState.CURRENT -> stepStyle.lineStyle.currentLineType
-        StepState.DONE -> stepStyle.lineStyle.doneLineType
+    val lineTrackStyle: LineType = when (stepState) {
+        StepState.TODO -> stepStyle.lineStyle.todoLineTrackType
+        StepState.CURRENT -> stepStyle.lineStyle.currentLineTrackType
+        StepState.DONE -> stepStyle.lineStyle.doneLineTrackType
+    }
+
+    val lineProgressStyle: LineType = when (stepState) {
+        StepState.TODO -> stepStyle.lineStyle.todoLineProgressType
+        StepState.CURRENT -> stepStyle.lineStyle.currentLineProgressType
+        StepState.DONE -> stepStyle.lineStyle.doneLineProgressType
     }
 
     val strokeCap: StrokeCap = when (stepState) {
@@ -159,7 +165,8 @@ internal fun HorizontalNumberedStep(
                 width = stepStyle.lineStyle.lineSize,
                 lineTrackColor = stepStyle.colors.todoLineColor,
                 lineProgressColor = lineColor,
-                lineStyle = lineStyle,
+                lineTrackStyle = lineTrackStyle,
+                lineProgressStyle = lineProgressStyle,
                 progress = lineProgress,
                 strokeCap = strokeCap
             )

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/horizontal/HorizontalTabStep.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/horizontal/HorizontalTabStep.kt
@@ -75,10 +75,16 @@ internal fun HorizontalTabStep(
         }
     }
 
-    val lineStyle: LineType = when (stepState) {
-        StepState.TODO -> stepStyle.lineStyle.todoLineType
-        StepState.CURRENT -> stepStyle.lineStyle.currentLineType
-        StepState.DONE -> stepStyle.lineStyle.doneLineType
+    val lineTrackStyle: LineType = when (stepState) {
+        StepState.TODO -> stepStyle.lineStyle.todoLineTrackType
+        StepState.CURRENT -> stepStyle.lineStyle.currentLineTrackType
+        StepState.DONE -> stepStyle.lineStyle.doneLineTrackType
+    }
+
+    val lineProgressStyle: LineType = when (stepState) {
+        StepState.TODO -> stepStyle.lineStyle.todoLineProgressType
+        StepState.CURRENT -> stepStyle.lineStyle.currentLineProgressType
+        StepState.DONE -> stepStyle.lineStyle.doneLineProgressType
     }
 
     val strokeCap: StrokeCap = when (stepState) {
@@ -146,7 +152,8 @@ internal fun HorizontalTabStep(
                 width = stepStyle.lineStyle.lineSize,
                 lineTrackColor = stepStyle.colors.todoLineColor,
                 lineProgressColor = lineColor,
-                lineStyle = lineStyle,
+                lineTrackStyle = lineTrackStyle,
+                lineProgressStyle = lineProgressStyle,
                 progress = lineProgress,
                 strokeCap = strokeCap
             )

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalIconStep.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalIconStep.kt
@@ -76,10 +76,16 @@ internal fun VerticalIconStep(
         }
     }
 
-    val lineStyle: LineType = when (stepState) {
-        StepState.TODO -> stepStyle.lineStyle.todoLineType
-        StepState.CURRENT -> stepStyle.lineStyle.currentLineType
-        StepState.DONE -> stepStyle.lineStyle.doneLineType
+    val lineTrackStyle: LineType = when (stepState) {
+        StepState.TODO -> stepStyle.lineStyle.todoLineTrackType
+        StepState.CURRENT -> stepStyle.lineStyle.currentLineTrackType
+        StepState.DONE -> stepStyle.lineStyle.doneLineTrackType
+    }
+
+    val lineProgressStyle: LineType = when (stepState) {
+        StepState.TODO -> stepStyle.lineStyle.todoLineProgressType
+        StepState.CURRENT -> stepStyle.lineStyle.currentLineProgressType
+        StepState.DONE -> stepStyle.lineStyle.doneLineProgressType
     }
 
     val strokeCap: StrokeCap = when (stepState) {
@@ -139,7 +145,8 @@ internal fun VerticalIconStep(
                 width = stepStyle.lineStyle.lineThickness,
                 lineTrackColor = stepStyle.colors.todoLineColor,
                 lineProgressColor = lineColor,
-                lineStyle = lineStyle,
+                lineTrackStyle = lineTrackStyle,
+                lineProgressStyle = lineProgressStyle,
                 progress = lineProgress,
                 strokeCap = strokeCap
             )

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalIconWithLabelStep.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalIconWithLabelStep.kt
@@ -87,10 +87,16 @@ internal fun VerticalIconWithLabelStep(
         }
     }
 
-    val lineStyle: LineType = when (stepState) {
-        StepState.TODO -> stepStyle.lineStyle.todoLineType
-        StepState.CURRENT -> stepStyle.lineStyle.currentLineType
-        StepState.DONE -> stepStyle.lineStyle.doneLineType
+    val lineTrackStyle: LineType = when (stepState) {
+        StepState.TODO -> stepStyle.lineStyle.todoLineTrackType
+        StepState.CURRENT -> stepStyle.lineStyle.currentLineTrackType
+        StepState.DONE -> stepStyle.lineStyle.doneLineTrackType
+    }
+
+    val lineProgressStyle: LineType = when (stepState) {
+        StepState.TODO -> stepStyle.lineStyle.todoLineProgressType
+        StepState.CURRENT -> stepStyle.lineStyle.currentLineProgressType
+        StepState.DONE -> stepStyle.lineStyle.doneLineProgressType
     }
 
     val strokeCap: StrokeCap = when (stepState) {
@@ -171,7 +177,8 @@ internal fun VerticalIconWithLabelStep(
                 width = stepStyle.lineStyle.lineThickness,
                 lineTrackColor = stepStyle.colors.todoLineColor,
                 lineProgressColor = lineColor,
-                lineStyle = lineStyle,
+                lineTrackStyle = lineTrackStyle,
+                lineProgressStyle = lineProgressStyle,
                 progress = lineProgress,
                 strokeCap = strokeCap
             )

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalNumberWithLabelStep.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalNumberWithLabelStep.kt
@@ -87,10 +87,16 @@ internal fun VerticalNumberWithLabelStep(
         }
     }
 
-    val lineStyle: LineType = when (stepState) {
-        StepState.TODO -> stepStyle.lineStyle.todoLineType
-        StepState.CURRENT -> stepStyle.lineStyle.currentLineType
-        StepState.DONE -> stepStyle.lineStyle.doneLineType
+    val lineTrackStyle: LineType = when (stepState) {
+        StepState.TODO -> stepStyle.lineStyle.todoLineTrackType
+        StepState.CURRENT -> stepStyle.lineStyle.currentLineTrackType
+        StepState.DONE -> stepStyle.lineStyle.doneLineTrackType
+    }
+
+    val lineProgressStyle: LineType = when (stepState) {
+        StepState.TODO -> stepStyle.lineStyle.todoLineProgressType
+        StepState.CURRENT -> stepStyle.lineStyle.currentLineProgressType
+        StepState.DONE -> stepStyle.lineStyle.doneLineProgressType
     }
 
     val strokeCap: StrokeCap = when (stepState) {
@@ -172,7 +178,8 @@ internal fun VerticalNumberWithLabelStep(
                 width = stepStyle.lineStyle.lineThickness,
                 lineTrackColor = stepStyle.colors.todoLineColor,
                 lineProgressColor = lineColor,
-                lineStyle = lineStyle,
+                lineTrackStyle = lineTrackStyle,
+                lineProgressStyle = lineProgressStyle,
                 progress = lineProgress,
                 strokeCap = strokeCap
             )

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalNumberedStep.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalNumberedStep.kt
@@ -78,10 +78,16 @@ internal fun VerticalNumberedStep(
         }
     }
 
-    val lineStyle: LineType = when (stepState) {
-        StepState.TODO -> stepStyle.lineStyle.todoLineType
-        StepState.CURRENT -> stepStyle.lineStyle.currentLineType
-        StepState.DONE -> stepStyle.lineStyle.doneLineType
+    val lineTrackStyle: LineType = when (stepState) {
+        StepState.TODO -> stepStyle.lineStyle.todoLineTrackType
+        StepState.CURRENT -> stepStyle.lineStyle.currentLineTrackType
+        StepState.DONE -> stepStyle.lineStyle.doneLineTrackType
+    }
+
+    val lineProgressStyle: LineType = when (stepState) {
+        StepState.TODO -> stepStyle.lineStyle.todoLineProgressType
+        StepState.CURRENT -> stepStyle.lineStyle.currentLineProgressType
+        StepState.DONE -> stepStyle.lineStyle.doneLineProgressType
     }
 
     val strokeCap: StrokeCap = when (stepState) {
@@ -142,7 +148,8 @@ internal fun VerticalNumberedStep(
                 width = stepStyle.lineStyle.lineThickness,
                 lineTrackColor = stepStyle.colors.todoLineColor,
                 lineProgressColor = lineColor,
-                lineStyle = lineStyle,
+                lineTrackStyle = lineTrackStyle,
+                lineProgressStyle = lineProgressStyle,
                 progress = lineProgress,
                 strokeCap = strokeCap
             )

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalTabStep.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalTabStep.kt
@@ -68,10 +68,16 @@ internal fun VerticalTabStep(
         }
     }
 
-    val lineStyle: LineType = when (stepState) {
-        StepState.TODO -> stepStyle.lineStyle.todoLineType
-        StepState.CURRENT -> stepStyle.lineStyle.currentLineType
-        StepState.DONE -> stepStyle.lineStyle.doneLineType
+    val lineTrackStyle: LineType = when (stepState) {
+        StepState.TODO -> stepStyle.lineStyle.todoLineTrackType
+        StepState.CURRENT -> stepStyle.lineStyle.currentLineTrackType
+        StepState.DONE -> stepStyle.lineStyle.doneLineTrackType
+    }
+
+    val lineProgressStyle: LineType = when (stepState) {
+        StepState.TODO -> stepStyle.lineStyle.todoLineProgressType
+        StepState.CURRENT -> stepStyle.lineStyle.currentLineProgressType
+        StepState.DONE -> stepStyle.lineStyle.doneLineProgressType
     }
 
     val strokeCap: StrokeCap = when (stepState) {
@@ -126,7 +132,8 @@ internal fun VerticalTabStep(
                 width = stepStyle.lineStyle.lineThickness,
                 lineTrackColor = stepStyle.colors.todoLineColor,
                 lineProgressColor = lineColor,
-                lineStyle = lineStyle,
+                lineTrackStyle = lineTrackStyle,
+                lineProgressStyle = lineProgressStyle,
                 progress = lineProgress,
                 strokeCap = strokeCap
             )

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalTabWithLabelStep.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalTabWithLabelStep.kt
@@ -79,10 +79,16 @@ internal fun VerticalTabWithLabelStep(
         }
     }
 
-    val lineStyle: LineType = when (stepState) {
-        StepState.TODO -> stepStyle.lineStyle.todoLineType
-        StepState.CURRENT -> stepStyle.lineStyle.currentLineType
-        StepState.DONE -> stepStyle.lineStyle.doneLineType
+    val lineTrackStyle: LineType = when (stepState) {
+        StepState.TODO -> stepStyle.lineStyle.todoLineTrackType
+        StepState.CURRENT -> stepStyle.lineStyle.currentLineTrackType
+        StepState.DONE -> stepStyle.lineStyle.doneLineTrackType
+    }
+
+    val lineProgressStyle: LineType = when (stepState) {
+        StepState.TODO -> stepStyle.lineStyle.todoLineProgressType
+        StepState.CURRENT -> stepStyle.lineStyle.currentLineProgressType
+        StepState.DONE -> stepStyle.lineStyle.doneLineProgressType
     }
 
     val strokeCap: StrokeCap = when (stepState) {
@@ -161,7 +167,8 @@ internal fun VerticalTabWithLabelStep(
                 width = stepStyle.lineStyle.lineThickness,
                 lineTrackColor = stepStyle.colors.todoLineColor,
                 lineProgressColor = lineColor,
-                lineStyle = lineStyle,
+                lineTrackStyle = lineTrackStyle,
+                lineProgressStyle = lineProgressStyle,
                 progress = lineProgress,
                 strokeCap = strokeCap
             )

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/model/StepStyle.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/model/StepStyle.kt
@@ -46,9 +46,12 @@ data class StepStyle(
  * @property linePaddingTop The top padding of the line.
  * @property linePaddingBottom The bottom padding of the line.
  * @property strokeCap The cap of the line.
- * @property todoLineType The style of the todo line.
- * @property currentLineType The style of the current line.
- * @property doneLineType The style of the done line.
+ * @property todoLineTrackType The track type of the todo line.
+ * @property currentLineTrackType The track type of the current line.
+ * @property doneLineTrackType The track type of the done line.
+ * @property todoLineProgressType The progress type of the todo line.
+ * @property currentLineProgressType The progress type of the current line.
+ * @property doneLineProgressType The progress type of the done line.
  */
 @Immutable
 data class LineDefault(
@@ -59,9 +62,12 @@ data class LineDefault(
     val linePaddingTop: Dp = 0.dp,
     val linePaddingBottom: Dp = 0.dp,
     val strokeCap: StrokeCap = StrokeCap.Square,
-    val todoLineType: LineType = LineType.SOLID,
-    val currentLineType: LineType = LineType.SOLID,
-    val doneLineType: LineType = LineType.SOLID
+    val todoLineTrackType: LineType = LineType.SOLID,
+    val currentLineTrackType: LineType = LineType.SOLID,
+    val doneLineTrackType: LineType = LineType.SOLID,
+    val todoLineProgressType: LineType = LineType.SOLID,
+    val currentLineProgressType: LineType = LineType.SOLID,
+    val doneLineProgressType: LineType = LineType.SOLID
 ) {
     companion object {
         fun defaultLine() = LineDefault(


### PR DESCRIPTION
### Tasks:
- [x] Segregate `lineType` into two attrs: `lineTrackType` and `lineProgressType`

### Breaking Changes:
- [x] If using `lineType`, please use `lineTrackType` and `lineProgressType` for better usability.