### PR TITLE
Strokes and shapes modifications

### DIFF
--- a/app/src/main/java/com/binayshaw7777/kotstep/MainActivity.kt
+++ b/app/src/main/java/com/binayshaw7777/kotstep/MainActivity.kt
@@ -120,6 +120,7 @@ fun MainPreview() {
         var lineBottomPadding by remember { mutableIntStateOf(0) }
         var lineStartPadding by remember { mutableIntStateOf(0) }
         var lineEndPadding by remember { mutableIntStateOf(0) }
+        var stepStroke by remember { mutableFloatStateOf(2f) }
         val strokeCapOptions = listOf("Rounded", "Butt", "Solid")
         val strokeCapOptionsMapped = listOf(StrokeCap.Round, StrokeCap.Butt, StrokeCap.Square)
         var trackStrokeCap by remember { mutableStateOf(strokeCapOptionsMapped[0]) }
@@ -166,6 +167,7 @@ fun MainPreview() {
             showCheckMarkOnDone = showCheckMark,
             showStrokeOnCurrent = showStepStroke,
             stepSize = stepItemSize.dp,
+            stepStroke = stepStroke,
             stepShape = getShapeFromEnum(currentStepperItemShape),
             colors = StepDefaults(
                 doneContainerColor = Color(0xFF00E676),
@@ -739,6 +741,20 @@ fun MainPreview() {
                 )
 
                 Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = "Step Stroke: $stepStroke",
+                    modifier = Modifier.padding(vertical = 4.dp)
+                )
+                Slider(
+                    value = stepStroke,
+                    onValueChange = { newValue ->
+                        stepStroke = newValue
+                    },
+                    valueRange = 1f..10f, // Set the range of Step Item size
+                    steps = 10, // Divide the range into 20 steps
+                    modifier = Modifier.fillMaxWidth()
+                )
 
                 Button(onClick = { showLineStyleSheet = true }) {
                     Text("Modify Line Style")

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/horizontal/HorizontalIconStep.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/horizontal/HorizontalIconStep.kt
@@ -133,7 +133,7 @@ internal fun HorizontalIconStep(
                 .then(
                     if (stepState == StepState.CURRENT && stepStyle.showStrokeOnCurrent) {
                         Modifier.border(
-                            BorderStroke(2.dp, stepStyle.colors.currentContainerColor),
+                            BorderStroke(stepStyle.stepStroke.dp, stepStyle.colors.currentContainerColor),
                             shape = stepStyle.stepShape
                         )
                     } else {

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/horizontal/HorizontalIconStep.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/horizontal/HorizontalIconStep.kt
@@ -145,7 +145,7 @@ internal fun HorizontalIconStep(
             if (stepState == StepState.DONE && stepStyle.showCheckMarkOnDone) {
                 Icon(
                     imageVector = Icons.Default.Done,
-                    tint = contentColor,
+                    tint = stepStyle.colors.checkMarkColor,
                     contentDescription = "Done"
                 )
             } else {

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/horizontal/HorizontalNumberedStep.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/horizontal/HorizontalNumberedStep.kt
@@ -147,7 +147,7 @@ internal fun HorizontalNumberedStep(
             if (stepState == StepState.DONE && stepStyle.showCheckMarkOnDone) {
                 Icon(
                     imageVector = Icons.Default.Done,
-                    tint = contentColor,
+                    tint = stepStyle.colors.checkMarkColor,
                     contentDescription = "Done"
                 )
             } else {

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/horizontal/HorizontalNumberedStep.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/horizontal/HorizontalNumberedStep.kt
@@ -135,7 +135,7 @@ internal fun HorizontalNumberedStep(
                 .then(
                     if (stepState == StepState.CURRENT && stepStyle.showStrokeOnCurrent) {
                         Modifier.border(
-                            BorderStroke(2.dp, stepStyle.colors.currentContainerColor),
+                            BorderStroke(stepStyle.stepStroke.dp, stepStyle.colors.currentContainerColor),
                             shape = stepStyle.stepShape
                         )
                     } else {

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/horizontal/HorizontalTabStep.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/horizontal/HorizontalTabStep.kt
@@ -127,14 +127,16 @@ internal fun HorizontalTabStep(
                 StepState.TODO -> {
                     TodoTab(
                         strokeColor = containerColor,
-                        strokeThickness = stepStyle.stepStroke
+                        strokeThickness = stepStyle.stepStroke,
+                        stepShape = stepStyle.stepShape
                     )
                 }
 
                 StepState.CURRENT -> {
                     CurrentTab(
                         circleColor = containerColor,
-                        strokeThickness = stepStyle.stepStroke
+                        strokeThickness = stepStyle.stepStroke,
+                        stepShape = stepStyle.stepShape
                     )
                 }
 
@@ -142,7 +144,8 @@ internal fun HorizontalTabStep(
                     DoneTab(
                         circleColor = containerColor,
                         showTick = stepStyle.showCheckMarkOnDone,
-                        tickColor = contentColor
+                        tickColor = contentColor,
+                        stepShape = stepStyle.stepShape
                     )
                 }
             }

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/horizontal/HorizontalTabStep.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/horizontal/HorizontalTabStep.kt
@@ -127,14 +127,14 @@ internal fun HorizontalTabStep(
                 StepState.TODO -> {
                     TodoTab(
                         strokeColor = containerColor,
-                        strokeThickness = stepStyle.lineStyle.lineThickness.value
+                        strokeThickness = stepStyle.stepStroke
                     )
                 }
 
                 StepState.CURRENT -> {
                     CurrentTab(
                         circleColor = containerColor,
-                        strokeThickness = stepStyle.lineStyle.lineThickness.value
+                        strokeThickness = stepStyle.stepStroke
                     )
                 }
 

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/horizontal/HorizontalTabStep.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/horizontal/HorizontalTabStep.kt
@@ -59,14 +59,6 @@ internal fun HorizontalTabStep(
         }
     }
 
-    val contentColor: Color by transition.animateColor(label = "contentColor") {
-        when (it) {
-            StepState.TODO -> stepStyle.colors.todoContentColor
-            StepState.CURRENT -> stepStyle.colors.currentContentColor
-            StepState.DONE -> stepStyle.colors.doneContentColor
-        }
-    }
-
     val lineColor: Color by transition.animateColor(label = "lineColor") {
         when (it) {
             StepState.TODO -> stepStyle.colors.todoLineColor
@@ -144,7 +136,7 @@ internal fun HorizontalTabStep(
                     DoneTab(
                         circleColor = containerColor,
                         showTick = stepStyle.showCheckMarkOnDone,
-                        tickColor = contentColor,
+                        checkMarkColor = stepStyle.colors.checkMarkColor,
                         stepShape = stepStyle.stepShape
                     )
                 }

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/tabs/CurrentTab.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/tabs/CurrentTab.kt
@@ -2,39 +2,58 @@ package com.binayshaw7777.kotstep.components.tabs
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawOutline
+import androidx.compose.ui.graphics.drawscope.Fill
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.unit.LayoutDirection
 
 /**
  * Represents the current tab in a tab stepper.
  *
  * @param circleColor The color of the circle.
- * @param outerCircleRadius The radius of the outer circle.
- * @param innerCircleRadius The radius of the inner circle.
  * @param strokeThickness The thickness of the stroke.
+ * @param stepShape The shape of the step.
  */
 @Composable
 internal fun CurrentTab(
     circleColor: Color = Color.Blue,
-    outerCircleRadius: Float? = null,
-    innerCircleRadius: Float? = null,
-    strokeThickness: Float = 4f
+    strokeThickness: Float = 4f,
+    stepShape: Shape = CircleShape
 ) {
-    Canvas(modifier = Modifier.fillMaxSize()) {
 
-        drawCircle(
+    Canvas(
+        modifier = Modifier
+            .fillMaxSize()
+            .clip(stepShape)
+    ) {
+        drawOutline(
+            outline = stepShape.createOutline(size, layoutDirection = LayoutDirection.Ltr, density = this),
             color = circleColor,
-            radius = outerCircleRadius ?: (size.minDimension / 2f),
-            center = center,
             style = Stroke(width = strokeThickness)
         )
 
-        drawCircle(
-            color = circleColor,
-            radius = innerCircleRadius ?: ((size.minDimension / 2f) * 0.7f),
-            center = center
-        )
+        val innerSize = Size(size.width * 0.7f, size.height * 0.7f)
+        val offsetX = (size.width - innerSize.width) / 2f
+        val offsetY = (size.height - innerSize.height) / 2f
+
+        translate(left = offsetX, top = offsetY) {
+            drawOutline(
+                outline = stepShape.createOutline(
+                    size = innerSize,
+                    layoutDirection = LayoutDirection.Ltr,
+                    density = this
+                ),
+                color = circleColor,
+                style = Fill
+            )
+        }
     }
 }

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/tabs/DoneTab.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/tabs/DoneTab.kt
@@ -24,14 +24,14 @@ import androidx.compose.ui.unit.dp
  *
  * @param circleColor The color of the circle.
  * @param showTick Whether to show the tick icon.
- * @param tickColor The color of the tick icon.
+ * @param checkMarkColor The color of the tick icon.
  * @param stepShape The shape of the step.
  */
 @Composable
 internal fun DoneTab(
     circleColor: Color = Color.Green,
     showTick: Boolean = false,
-    tickColor: Color = Color.White,
+    checkMarkColor: Color = Color.White,
     stepShape: Shape = CircleShape
 ) {
     val painter = rememberVectorPainter(Icons.Default.Done)
@@ -60,7 +60,7 @@ internal fun DoneTab(
                     draw(
                         size = Size(iconSize, iconSize),
                         alpha = 1f,
-                        colorFilter = ColorFilter.tint(tickColor)
+                        colorFilter = ColorFilter.tint(checkMarkColor)
                     )
                 }
             }

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/tabs/DoneTab.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/tabs/DoneTab.kt
@@ -2,39 +2,53 @@ package com.binayshaw7777.kotstep.components.tabs
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawOutline
+import androidx.compose.ui.graphics.drawscope.Fill
 import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 
 /**
  * Represents the done tab in a tab stepper.
  *
  * @param circleColor The color of the circle.
- * @param circleRadius The radius of the circle.
  * @param showTick Whether to show the tick icon.
  * @param tickColor The color of the tick icon.
+ * @param stepShape The shape of the step.
  */
 @Composable
 internal fun DoneTab(
     circleColor: Color = Color.Green,
-    circleRadius: Float? = null,
     showTick: Boolean = false,
-    tickColor: Color = Color.White
+    tickColor: Color = Color.White,
+    stepShape: Shape = CircleShape
 ) {
     val painter = rememberVectorPainter(Icons.Default.Done)
 
-    Canvas(modifier = Modifier.fillMaxSize()) {
-        drawCircle(
+    Canvas(
+        modifier = Modifier
+            .fillMaxSize()
+            .clip(stepShape)
+    ) {
+        drawOutline(
+            outline = stepShape.createOutline(
+                size,
+                layoutDirection = LayoutDirection.Ltr,
+                density = this
+            ),
             color = circleColor,
-            radius = circleRadius ?: (size.minDimension / 2f),
-            center = center
+            style = Fill
         )
 
         if (showTick) {

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/tabs/TodoTab.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/tabs/TodoTab.kt
@@ -2,29 +2,32 @@ package com.binayshaw7777.kotstep.components.tabs
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawOutline
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.unit.LayoutDirection
 
 /**
  * Represents the todo tab in a tab stepper.
  *
  * @param strokeColor The color of the stroke.
- * @param circleRadius The radius of the circle.
  * @param strokeThickness The thickness of the stroke.
+ * @param stepShape The shape of the step.
  */
 @Composable
 internal fun TodoTab(
     strokeColor: Color = Color.Gray,
-    circleRadius: Float? = null,
     strokeThickness: Float = 4f,
+    stepShape: Shape = CircleShape
 ) {
     Canvas(modifier = Modifier.fillMaxSize()) {
-        drawCircle(
+        drawOutline(
+            outline = stepShape.createOutline(size, layoutDirection = LayoutDirection.Ltr, density = this),
             color = strokeColor,
-            radius = circleRadius ?: (size.minDimension / 2f),
-            center = center,
             style = Stroke(width = strokeThickness)
         )
     }

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalIconStep.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalIconStep.kt
@@ -116,7 +116,7 @@ internal fun VerticalIconStep(
                 .then(
                     if (stepState == StepState.CURRENT && stepStyle.showStrokeOnCurrent) {
                         Modifier.border(
-                            BorderStroke(2.dp, stepStyle.colors.currentContainerColor),
+                            BorderStroke(stepStyle.stepStroke.dp, stepStyle.colors.currentContainerColor),
                             shape = stepStyle.stepShape
                         )
                     } else {

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalIconStep.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalIconStep.kt
@@ -128,7 +128,7 @@ internal fun VerticalIconStep(
             if (stepState == StepState.DONE && stepStyle.showCheckMarkOnDone) {
                 Icon(
                     imageVector = Icons.Default.Done,
-                    tint = contentColor,
+                    tint = stepStyle.colors.checkMarkColor,
                     contentDescription = "Done"
                 )
             } else {

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalIconWithLabelStep.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalIconWithLabelStep.kt
@@ -132,7 +132,7 @@ internal fun VerticalIconWithLabelStep(
                 .then(
                     if (stepState == StepState.CURRENT && stepStyle.showStrokeOnCurrent) {
                         Modifier.border(
-                            BorderStroke(2.dp, stepStyle.colors.currentContainerColor),
+                            BorderStroke(stepStyle.stepStroke.dp, stepStyle.colors.currentContainerColor),
                             shape = stepStyle.stepShape
                         )
                     } else {

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalIconWithLabelStep.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalIconWithLabelStep.kt
@@ -147,7 +147,7 @@ internal fun VerticalIconWithLabelStep(
             if (stepState == StepState.DONE && stepStyle.showCheckMarkOnDone) {
                 Icon(
                     imageVector = Icons.Default.Done,
-                    tint = contentColor,
+                    tint = stepStyle.colors.checkMarkColor,
                     contentDescription = "Done"
                 )
             } else {

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalNumberWithLabelStep.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalNumberWithLabelStep.kt
@@ -133,7 +133,7 @@ internal fun VerticalNumberWithLabelStep(
                 .then(
                     if (stepState == StepState.CURRENT && stepStyle.showStrokeOnCurrent) {
                         Modifier.border(
-                            BorderStroke(2.dp, stepStyle.colors.currentContainerColor),
+                            BorderStroke(stepStyle.stepStroke.dp, stepStyle.colors.currentContainerColor),
                             shape = stepStyle.stepShape
                         )
                     } else {

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalNumberWithLabelStep.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalNumberWithLabelStep.kt
@@ -148,7 +148,7 @@ internal fun VerticalNumberWithLabelStep(
             if (stepState == StepState.DONE && stepStyle.showCheckMarkOnDone) {
                 Icon(
                     imageVector = Icons.Default.Done,
-                    tint = contentColor,
+                    tint = stepStyle.colors.checkMarkColor,
                     contentDescription = "Done"
                 )
             } else {

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalNumberedStep.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalNumberedStep.kt
@@ -118,7 +118,7 @@ internal fun VerticalNumberedStep(
                 .then(
                     if (stepState == StepState.CURRENT && stepStyle.showStrokeOnCurrent) {
                         Modifier.border(
-                            BorderStroke(2.dp, stepStyle.colors.currentContainerColor),
+                            BorderStroke(stepStyle.stepStroke.dp, stepStyle.colors.currentContainerColor),
                             shape = stepStyle.stepShape
                         )
                     } else {

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalNumberedStep.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalNumberedStep.kt
@@ -130,7 +130,7 @@ internal fun VerticalNumberedStep(
             if (stepState == StepState.DONE && stepStyle.showCheckMarkOnDone) {
                 Icon(
                     imageVector = Icons.Default.Done,
-                    tint = contentColor,
+                    tint = stepStyle.colors.checkMarkColor,
                     contentDescription = "Done"
                 )
             } else {

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalTabStep.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalTabStep.kt
@@ -107,14 +107,14 @@ internal fun VerticalTabStep(
                 StepState.TODO -> {
                     TodoTab(
                         strokeColor = containerColor,
-                        strokeThickness = stepStyle.lineStyle.lineThickness.value
+                        strokeThickness = stepStyle.stepStroke
                     )
                 }
 
                 StepState.CURRENT -> {
                     CurrentTab(
                         circleColor = containerColor,
-                        strokeThickness = stepStyle.lineStyle.lineThickness.value
+                        strokeThickness = stepStyle.stepStroke
                     )
                 }
 

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalTabStep.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalTabStep.kt
@@ -107,14 +107,16 @@ internal fun VerticalTabStep(
                 StepState.TODO -> {
                     TodoTab(
                         strokeColor = containerColor,
-                        strokeThickness = stepStyle.stepStroke
+                        strokeThickness = stepStyle.stepStroke,
+                        stepShape = stepStyle.stepShape
                     )
                 }
 
                 StepState.CURRENT -> {
                     CurrentTab(
                         circleColor = containerColor,
-                        strokeThickness = stepStyle.stepStroke
+                        strokeThickness = stepStyle.stepStroke,
+                        stepShape = stepStyle.stepShape,
                     )
                 }
 
@@ -122,7 +124,8 @@ internal fun VerticalTabStep(
                     DoneTab(
                         circleColor = containerColor,
                         showTick = stepStyle.showCheckMarkOnDone,
-                        tickColor = contentColor
+                        tickColor = contentColor,
+                        stepShape = stepStyle.stepShape
                     )
                 }
             }

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalTabStep.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalTabStep.kt
@@ -52,14 +52,6 @@ internal fun VerticalTabStep(
         }
     }
 
-    val contentColor: Color by transition.animateColor(label = "contentColor") {
-        when (it) {
-            StepState.TODO -> stepStyle.colors.todoContentColor
-            StepState.CURRENT -> stepStyle.colors.currentContentColor
-            StepState.DONE -> stepStyle.colors.doneContentColor
-        }
-    }
-
     val lineColor: Color by transition.animateColor(label = "lineColor") {
         when (it) {
             StepState.TODO -> stepStyle.colors.todoLineColor
@@ -124,7 +116,7 @@ internal fun VerticalTabStep(
                     DoneTab(
                         circleColor = containerColor,
                         showTick = stepStyle.showCheckMarkOnDone,
-                        tickColor = contentColor,
+                        checkMarkColor = stepStyle.colors.checkMarkColor,
                         stepShape = stepStyle.stepShape
                     )
                 }

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalTabWithLabelStep.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalTabWithLabelStep.kt
@@ -128,14 +128,14 @@ internal fun VerticalTabWithLabelStep(
                 StepState.TODO -> {
                     TodoTab(
                         strokeColor = containerColor,
-                        strokeThickness = stepStyle.lineStyle.lineThickness.value
+                        strokeThickness = stepStyle.stepStroke
                     )
                 }
 
                 StepState.CURRENT -> {
                     CurrentTab(
                         circleColor = containerColor,
-                        strokeThickness = stepStyle.lineStyle.lineThickness.value
+                        strokeThickness = stepStyle.stepStroke
                     )
                 }
 

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalTabWithLabelStep.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalTabWithLabelStep.kt
@@ -63,14 +63,6 @@ internal fun VerticalTabWithLabelStep(
         }
     }
 
-    val contentColor: Color by transition.animateColor(label = "contentColor") {
-        when (it) {
-            StepState.TODO -> stepStyle.colors.todoContentColor
-            StepState.CURRENT -> stepStyle.colors.currentContentColor
-            StepState.DONE -> stepStyle.colors.doneContentColor
-        }
-    }
-
     val lineColor: Color by transition.animateColor(label = "lineColor") {
         when (it) {
             StepState.TODO -> stepStyle.colors.todoLineColor
@@ -145,7 +137,7 @@ internal fun VerticalTabWithLabelStep(
                     DoneTab(
                         circleColor = containerColor,
                         showTick = stepStyle.showCheckMarkOnDone,
-                        tickColor = contentColor,
+                        checkMarkColor = stepStyle.colors.checkMarkColor,
                         stepShape = stepStyle.stepShape
                     )
                 }

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalTabWithLabelStep.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/components/vertical/VerticalTabWithLabelStep.kt
@@ -128,14 +128,16 @@ internal fun VerticalTabWithLabelStep(
                 StepState.TODO -> {
                     TodoTab(
                         strokeColor = containerColor,
-                        strokeThickness = stepStyle.stepStroke
+                        strokeThickness = stepStyle.stepStroke,
+                        stepShape = stepStyle.stepShape
                     )
                 }
 
                 StepState.CURRENT -> {
                     CurrentTab(
                         circleColor = containerColor,
-                        strokeThickness = stepStyle.stepStroke
+                        strokeThickness = stepStyle.stepStroke,
+                        stepShape = stepStyle.stepShape
                     )
                 }
 
@@ -143,7 +145,8 @@ internal fun VerticalTabWithLabelStep(
                     DoneTab(
                         circleColor = containerColor,
                         showTick = stepStyle.showCheckMarkOnDone,
-                        tickColor = contentColor
+                        tickColor = contentColor,
+                        stepShape = stepStyle.stepShape
                     )
                 }
             }

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/model/StepStyle.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/model/StepStyle.kt
@@ -111,6 +111,7 @@ data class StepDefaults(
     val doneContainerColor: Color = Color.Green,
     val doneContentColor: Color = Color.White,
     val doneLineColor: Color = Color.Green,
+    val tickColor: Color = Color.Black
 ) {
     companion object {
         /**
@@ -127,7 +128,8 @@ data class StepDefaults(
             currentLineColor = Color.Blue,
             doneContainerColor = Color.Green,
             doneContentColor = Color.White,
-            doneLineColor = Color.Green
+            doneLineColor = Color.Green,
+            tickColor = Color.Black
         )
     }
 }

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/model/StepStyle.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/model/StepStyle.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.unit.sp
  * @property colors The colors of the steps.
  * @property stepSize The size of the step.
  * @property stepShape The shape of the step.
+ * @property stepStroke The stroke of the step.
  * @property textSize The size of the text.
  * @property iconSize The size of the icon.
  * @property stepPadding The padding of the step.
@@ -28,6 +29,7 @@ data class StepStyle(
     val lineStyle: LineDefault = LineDefault.defaultLine(),
     val stepSize: Dp = 36.dp,
     val stepShape: Shape = CircleShape,
+    val stepStroke: Float = 2f,
     val textSize: TextUnit = 16.sp,
     val iconSize: Dp = 24.dp,
     val stepPadding: Dp = 0.dp,
@@ -45,7 +47,8 @@ data class StepStyle(
  * @property linePaddingEnd The end padding of the line.
  * @property linePaddingTop The top padding of the line.
  * @property linePaddingBottom The bottom padding of the line.
- * @property strokeCap The cap of the line.
+ * @property trackStrokeCap The stroke cap of the track.
+ * @property progressStrokeCap The stroke cap of the progress.
  * @property todoLineTrackType The track type of the todo line.
  * @property currentLineTrackType The track type of the current line.
  * @property doneLineTrackType The track type of the done line.

--- a/kotstep/src/main/java/com/binayshaw7777/kotstep/model/StepStyle.kt
+++ b/kotstep/src/main/java/com/binayshaw7777/kotstep/model/StepStyle.kt
@@ -99,6 +99,7 @@ data class LineDefault(
  * @property doneContainerColor The color of the done container.
  * @property doneContentColor The color of the done content.
  * @property doneLineColor The color of the done line.
+ * @property checkMarkColor The color of the check mark.
  */
 @Immutable
 data class StepDefaults(
@@ -111,7 +112,7 @@ data class StepDefaults(
     val doneContainerColor: Color = Color.Green,
     val doneContentColor: Color = Color.White,
     val doneLineColor: Color = Color.Green,
-    val tickColor: Color = Color.Black
+    val checkMarkColor: Color = Color.Black
 ) {
     companion object {
         /**
@@ -129,7 +130,7 @@ data class StepDefaults(
             doneContainerColor = Color.Green,
             doneContentColor = Color.White,
             doneLineColor = Color.Green,
-            tickColor = Color.Black
+            checkMarkColor = Color.Black
         )
     }
 }


### PR DESCRIPTION
### Changes:
- [x] Segregated and introduces `stepStroke` from `lineThickness`
- [x] Introduces `stepShape` in all tabs steppers
- [x] Introduces `checkMarkColor` as in Colors for Tick/Check mark Icons on DONE state

### Breaking Changes?
- As of no, you might need to check for your `lineThickness` if that affects your step's stroke. In that case, please use `stepStroke` param in `StepStyle`.